### PR TITLE
Fix stray import in RootLayout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,4 +31,3 @@ export default function RootLayout({
 }
 
 
-import './globals.css'


### PR DESCRIPTION
## Summary
- remove duplicated import in `RootLayout`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f3035eec832e8d7ceed76aa5d0fb